### PR TITLE
Export TodoList

### DIFF
--- a/todos/todo.mjs
+++ b/todos/todo.mjs
@@ -66,7 +66,7 @@ class Todo extends ObservableObject {
 	}
 }
 
-Todo.List = class TodoList extends ObservableArray {
+export class TodoList extends ObservableArray {
 	// Specify the behavior of items in the TodoList
 	static items = type.convert(Todo);
 


### PR DESCRIPTION
This exports `TodoList` and doesn’t assign the class to `Todo.List` because 1) we’re renaming `List` to `ArrayType` and 2) we’re not adding support for configuring `ArrayType` by reading `ObjectType.ArrayType`.